### PR TITLE
Fixed problem with meta description

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -475,7 +475,10 @@ class ContentExtractor(object):
     def get_meta_description(self, doc):
         """If the article has meta description set in the source, use that
         """
-        return self.get_meta_content(doc, "meta[name=description]")
+        if len(self.get_meta_content(doc, "meta[name=description]")) > len(self.get_meta_content(doc, "meta[property=description]")):
+          return self.get_meta_content(doc, "meta[name=description]")
+      
+        return self.get_meta_content(doc, "meta[property=description]")
 
     def get_meta_keywords(self, doc):
         """If the article has meta keywords set in the source, use that


### PR DESCRIPTION
I have found examples where sites use the syntax <meta property="description" ... 

This makes the get_meta_description return "". Added check to see if the doc uses the property syntax instead.